### PR TITLE
Allow ENOTSOCK errno in test-net-listen-fd0.js

### DIFF
--- a/test/simple/test-net-listen-fd0.js
+++ b/test/simple/test-net-listen-fd0.js
@@ -29,8 +29,13 @@ process.on('exit', function() {
   assert.equal(gotError, true);
 });
 
-// this should fail with an async EINVAL error, not throw an exception
+// This tests a corner case to ensure file descriptor 0 is treated
+// like any other file descriptor.
+// This should fail with an async error, not throw an exception.
 net.createServer(assert.fail).listen({fd:0}).on('error', function(e) {
-  assert.equal(e.code, 'EINVAL');
+  // On UNIX, the errno may be ENOTSOCK rather than EINVAL in the case 
+  // where fd 0 is a named or unnamed pipe
+  assert(e.code == 'EINVAL' || e.code == 'ENOTSOCK', 
+         e.code + " in ['EINVAL', 'ENOTSOCK']");
   gotError = true;
 });


### PR DESCRIPTION
On UNIX, if fd 0 (stdin) is an unnamed or named pipe (for example,
if the test is run with "echo | node test/simple/test-net-listen-fd0.js",
or from Jenkins) then node will not distinguish it from a UNIX
domain socket and will attempt to listen() on the fd even though
it will always fail with ENOTSOCK.

Also note that an EINVAL errno here is likely injected by node rather
than a real errno returned from calling listen().

This test appears to be concerned with testing for a particular
corner case where fd = 0 and ensuring it doesn't throw an exception,
so in this case we can just accept ENOTSOCK as well as EINVAL and
be happy the intended corner case is still tested.
