### PR TITLE
[z/OS] Fixed compiling Cares dependency in z/OS.

### DIFF
--- a/deps/cares/build.mk
+++ b/deps/cares/build.mk
@@ -83,6 +83,7 @@ OBJS += src/ares_platform.o
 LDFLAGS += -lws2_32.lib -liphlpapi.lib
 else
 ifneq (,$(findstring os/390,$(OS)))
+ARES_CONFIG_OS = OS390
 CFLAGS += -g
 CFLAGS += -qXPLINK
 CFLAGS += -D_LARGEFILE_SOURCE

--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -156,6 +156,10 @@
           'include_dirs': [ 'config/aix' ],
           'sources': [ 'config/aix/ares_config.h' ],
         }],
+        [ 'OS=="os390"', {
+          'include_dirs': [ 'config/OS390' ],
+          'sources': [ 'config/OS390/ares_config.h' ],
+        }],
         [ 'OS=="solaris"', {
           'include_dirs': [ 'config/sunos' ],
           'sources': [ 'config/sunos/ares_config.h' ],


### PR DESCRIPTION
Cares will now build properly when compiled with 'make' in deps/cares directory