### PR TITLE
Reorder the xlC command line used for linking

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -98,6 +98,8 @@
         ],
         'ldflags': [
           '-q64',
+        ],
+        'libraries': [
           '<(node_exp_file)'
         ],
       }],


### PR DESCRIPTION
Reorder the xlC command line used for linking to put options with flags ahead of files to be processed