### PR TITLE
Explicitly mark message queue events on os390

### DIFF
--- a/deps/uv/src/unix/os390-syscalls.c
+++ b/deps/uv/src/unix/os390-syscalls.c
@@ -242,7 +242,7 @@ int epoll_ctl(uv__os390_epoll* lst,
   uv_mutex_lock(&global_epoll_lock);
 
   if (op == EPOLL_CTL_DEL) {
-    if (fd == lst->msg_queue) {
+    if (event->is_msg) {
       /* The user has deleted the System V message queue. Highly likely
        * because the process is being shut down. So stop listening to it.
        */
@@ -316,6 +316,11 @@ int epoll_wait(uv__os390_epoll* lst, struct epoll_event* events,
 
     ev.fd = pfd->fd;
     ev.events = pfd->revents;
+    if (i == lst->size - 1)
+      ev.is_msg = 1;
+    else
+      ev.is_msg = 0;
+
     if (pfd->revents & POLLIN && pfd->revents & POLLOUT)
       reventcount += 2;
     else if (pfd->revents & (POLLIN | POLLOUT))

--- a/deps/uv/src/unix/os390-syscalls.h
+++ b/deps/uv/src/unix/os390-syscalls.h
@@ -44,6 +44,7 @@
 struct epoll_event {
   int events;
   int fd;
+  int is_msg;
 };
 
 typedef struct {

--- a/deps/uv/src/unix/os390.c
+++ b/deps/uv/src/unix/os390.c
@@ -669,6 +669,9 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
         events[i].fd = -1;
 
   /* Remove the file descriptor from the epoll. */
+  dummy.events = 0;
+  dummy.fd = fd;
+  dummy.is_msg = 0;
   if (loop->ep != NULL)
     epoll_ctl(loop->ep, UV__EPOLL_CTL_DEL, fd, &dummy);
 }
@@ -846,6 +849,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
     e.events = w->pevents;
     e.fd = w->fd;
+    e.is_msg = 0;
 
     if (w->events == 0)
       op = UV__EPOLL_CTL_ADD;
@@ -928,7 +932,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         continue;
 
       ep = loop->ep;
-      if (fd == ep->msg_queue) {
+      if (pe->is_msg) {
         if (os390_message_queue_handler(ep) == -1) {
           /* The user has deleted the System V message queue. Highly likely
            * because the process is being shut down. So stop listening to it.


### PR DESCRIPTION
The os390 epoll_wait implementation uses poll() to detect events in
both file descriptors and the message queue used for file system
events. The only message queue ID is always placed at the end of the
array passed to the poll() call. When the poll() call returns all FDs
and the message queue are checked for events by iterating through that
array. In order to distinguish the message queue from the FDs its ID
value is compared with the only message queue ID we have and if it
matches the message queue handler function is called.

When the message queue ID is relatively small, it may have the same
value as the value of one of the file descriptors. If this happens,
the message queue handler is called for the matching file descriptor,
and this call fails. The file descriptor ends up being unhandled and
this makes the next poll() call to return immediately. Eventually this
will happen again and again, leading to an infinite busy loop and high
CPU usage.

To prevent the incorrect interpretation of file descriptors as the
message queue, a new field has been added to the epoll event struct.
This field is checked instead of the ID value and the message queue
handler function is never called for file descriptors.

This PR should resolve issue https://github.com/ibmruntimes/node/issues/104