### PR TITLE
Fixed imports to make test-process-kill-null.js test work on zOS

### DIFF
--- a/test/parallel/test-process-kill-null.js
+++ b/test/parallel/test-process-kill-null.js
@@ -1,9 +1,8 @@
 'use strict';
-const { mustCall } = require('../common');
+const { mustCall, spawnCat } = require('../common');
 const assert = require('assert');
-const { spawn } = require('child_process');
 
-const cat = common.spawnCat();
+const cat = spawnCat();
 
 assert.ok(process.kill(cat.pid, 0));
 


### PR DESCRIPTION
Patch to fix test/parallel/test-process-kill-null case on zOS.
Added zOS specific spawnCat import.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
